### PR TITLE
chore: Fix support for Node.js 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.7",
       "license": "MIT",
       "dependencies": {
-        "@achrinza/strong-type": "0.1.7"
+        "@achrinza/strong-type": "0.1.8"
       },
       "devDependencies": {
         "@node-ipc/vanilla-test": "1.4.10",
@@ -22,11 +22,11 @@
       }
     },
     "node_modules/@achrinza/strong-type": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.7.tgz",
-      "integrity": "sha512-RX2ntDMRYUiTlGl+0RE7R6FSrM+Wq+uZzAMWK/G7JQ1VA2+DifcMA4Y3U5tHcnwCmmawNtRQuuHbQZSlOcbNpA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.8.tgz",
+      "integrity": "sha512-yL/NlZbL6S+pQn7+b6eFAIzqyS9uXYZcSGsdQx/H8j8GRkszWGHmsgS41WT9Si/JyzXuJi7ieHqyWw5YIwrBTA==",
       "engines": {
-        "node": "12 || 13 || 14 || 15 || 16 || 17"
+        "node": "12 || 13 || 14 || 15 || 16 || 17 || 18"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1046,9 +1046,9 @@
   },
   "dependencies": {
     "@achrinza/strong-type": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.7.tgz",
-      "integrity": "sha512-RX2ntDMRYUiTlGl+0RE7R6FSrM+Wq+uZzAMWK/G7JQ1VA2+DifcMA4Y3U5tHcnwCmmawNtRQuuHbQZSlOcbNpA=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.8.tgz",
+      "integrity": "sha512-yL/NlZbL6S+pQn7+b6eFAIzqyS9uXYZcSGsdQx/H8j8GRkszWGHmsgS41WT9Si/JyzXuJi7ieHqyWw5YIwrBTA=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "c8": "^7.6.0"
   },
   "dependencies": {
-    "@achrinza/strong-type": "0.1.7"
+    "@achrinza/strong-type": "0.1.8"
   }
 }


### PR DESCRIPTION
The initial support for Node.js 18 done in https://github.com/achrinza/event-pubsub/commit/9e2052d4c36ed735d660d74761659e5b518a014d was not enough because trying to use this package in Node.js 18 would still fail on the required version of @achrinza/strong-type dependency, which didn't support node 18.

I see that tests on this repo pass with node 18 (only showing warnings https://github.com/achrinza/event-pubsub/runs/7947184803?check_suite_focus=true), but when I was using this package in a project on a private repo, it was not warnings but errors. I'm not sure why exactly, but maybe because of using yarn instead of npm.

Note that this solves node 18 support only for production use of this package. For development in node 18, it also requires to bump the version in https://github.com/node-ipc/vanilla-test/blob/8e2cfbce5c9a3f98faeb8ae1b7508d4131064cee/package.json#L31 and release a new patch of that package.
